### PR TITLE
trace onDropped error

### DIFF
--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -123,7 +123,7 @@ export class EventStoreBus {
     try {
       await this.eventStore.connection.appendToStream(stream, -2, [payload]);
     } catch (err) {
-      this.logger.error(err);
+      this.logger.error(err.message, err.stack);
     }
   }
 
@@ -143,7 +143,7 @@ export class EventStoreBus {
           this.onDropped(sub as ExtendedCatchUpSubscription, reason, error),
       ) as ExtendedCatchUpSubscription;
     } catch (err) {
-      this.logger.error(err.message);
+      this.logger.error(err.message, err.stack);
     }
   }
 
@@ -167,7 +167,7 @@ export class EventStoreBus {
 
       return resolved;
     } catch (err) {
-      this.logger.error(err.message);
+      this.logger.error(err.message, err.stack);
     }
   }
 

--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -197,7 +197,7 @@ export class EventStoreBus {
     error: Error,
   ) {
     subscription.isLive = false;
-    this.logger.error(error);
+    this.logger.error(error.message, error.stack);
   }
 
   onLiveProcessingStarted(subscription: ExtendedCatchUpSubscription) {


### PR DESCRIPTION
Logger write empty object `{}` when onDropped is triggered.

https://github.com/daypaio/nestjs-eventstore/blob/20d20ba40de1379c6854824132e4f182873d50e3/src/event-store/eventstore-cqrs/event-store.bus.ts#L194-L201