### PR TITLE
Added support for resolving nonlink events.

### DIFF
--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -178,7 +178,7 @@ export class EventStoreBus {
     payload: ResolvedEvent,
   ) {
     const { event } = payload;
-    if (!payload.isResolved || !event || !event.isJson) {
+    if ((payload.link !== null && !payload.isResolved) || !event || !event.isJson) {
       this.logger.error('Received event that could not be resolved!');
       return;
     }


### PR DESCRIPTION
onEvent() throws 'Could not be resolved'-error for non-link events, even though nothing needs to be resolved ([link](https://eventstore.org/blog/20130306/getting-started-part-3-subscriptions/)).