### PR TITLE
Give event initiator more info 

### DIFF
--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -187,8 +187,9 @@ export class EventStoreBus {
       this.logger.error('Received event that could not be handled!');
       return;
     }
-    const data = Object.values(JSON.parse(event.data.toString()));
-    this.subject$.next(this.eventHandlers[event.eventType](...data));
+    const data = JSON.parse(event.data.toString());
+    const metadata = JSON.parse(event.metadata.toString());
+    this.subject$.next(this.eventHandlers[event.eventType](data, metadata, event.eventId, event.eventStreamId, new Date(event.created)));
   }
 
   onDropped(


### PR DESCRIPTION
 - changed data to give keys and values
 - added metadata  
 - added event id
 - added stream name
 - added created date 

Eventstore has metadata built in with some vital information that can be passed by (ie. correlation_id, causation_id, version ...).
Handling events without this data can be problematic.

I understand that IEvent should not need all this to be compatible but it's the point of EventHandlersInitators no ? (or what's its point ?)