### PR TITLE
Enable catchup subscriptions to start from a specific event number

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Injects eventstore connector modules, components, bus and eventstore config into
 #### Using the EventStoreCqrsModule
 
 `EventStoreCqrsModule` uses `@nestjs/cqrs` module under the hood. It overrides the default eventbus of `@nestjs/cqrs` and pushes the event to the eventstore rather than the internal eventBus.
-Therefore the `eventBus.publish(event, streamName)` method takes [two arguments instead of one](https://github.com/daypaio/nestjs-eventstore/blob/2e09dd435c60a1a881b9b012d6c83f810b3c85da/src/event-store/eventstore-cqrs/event-store.bus.ts#L115). The first one is the event itself, and the second one is the stream name. 
+Therefore the `eventBus.publish(event, streamName)` method takes [two arguments instead of one](https://github.com/daypaio/nestjs-eventstore/blob/2e09dd435c60a1a881b9b012d6c83f810b3c85da/src/event-store/eventstore-cqrs/event-store.bus.ts#L115). The first one is the event itself, and the second one is the stream name.
 
 Once the event is pushed to the eventStore all the subscriptions listening to that event are pushed that event from the event store. Event handlers can then be triggered to cater for those events.
 
@@ -51,6 +51,7 @@ export const eventStoreBusConfig: EventStoreBusConfig = {
     { // Catchup subscription
       type: EventStoreSubscriptionType.CatchUp,
       stream: '$ce-users',
+      startFrom: 0,
     },
   ],
   eventInstantiators: {

--- a/src/event-store/eventstore-cqrs/event-bus.provider.ts
+++ b/src/event-store/eventstore-cqrs/event-bus.provider.ts
@@ -33,7 +33,7 @@ export type EventStorePersistentSubscription = {
 export type EventStoreCatchupSubscription = {
   type: EventStoreSubscriptionType.CatchUp;
   stream: string;
-  startFrom: Number;
+  startFrom?: Number;
 };
 
 export type EventStoreSubscriptionConfig = {

--- a/src/event-store/eventstore-cqrs/event-bus.provider.ts
+++ b/src/event-store/eventstore-cqrs/event-bus.provider.ts
@@ -33,6 +33,7 @@ export type EventStorePersistentSubscription = {
 export type EventStoreCatchupSubscription = {
   type: EventStoreSubscriptionType.CatchUp;
   stream: string;
+  startFrom: Number;
 };
 
 export type EventStoreSubscriptionConfig = {

--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -80,7 +80,7 @@ export class EventStoreBus {
   subscribeToCatchUpSubscriptions(subscriptions: ESCatchUpSubscription[]) {
     this.catchupSubscriptionsCount = subscriptions.length;
     this.catchupSubscriptions = subscriptions.map((subscription) => {
-      return this.subscribeToCatchupSubscription(subscription.stream);
+      return this.subscribeToCatchupSubscription(subscription.stream, subscription.startFrom || 0);
     });
   }
 
@@ -142,12 +142,12 @@ export class EventStoreBus {
     }
   }
 
-  subscribeToCatchupSubscription(stream: string): ExtendedCatchUpSubscription {
+  subscribeToCatchupSubscription(stream: string, startFrom: Number): ExtendedCatchUpSubscription {
     this.logger.log(`Catching up and subscribing to stream ${stream}!`);
     try {
       return this.eventStore.connection.subscribeToStreamFrom(
         stream,
-        0,
+        startFrom,
         true,
         (sub, payload) => this.onEvent(sub, payload),
         subscription =>


### PR DESCRIPTION
Currently, all catchup subscriptions start from event 0. This may not be what is needed and may be expensive when restarting a service. This change enables developers to define the starting event by adding an optional  `startFrom` member to the `EventStoreCatchupSubscription` type.