### PR TITLE
persistent subscriptions reconnect

### DIFF
--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -54,13 +54,14 @@ export class EventStoreBus {
       return sub.type === EventStoreSubscriptionType.Persistent;
     });
 
-    this.subscribeToCatchUpSubscriptions(
-      catchupSubscriptions as ESCatchUpSubscription[],
-    );
-
-    this.subscribeToPersistentSubscriptions(
-      persistentSubscriptions as ESPersistentSubscription[],
-    );
+    this.eventStore.connection.on('connected', () => {
+      this.subscribeToCatchUpSubscriptions(
+        catchupSubscriptions as ESCatchUpSubscription[],
+      );
+      this.subscribeToPersistentSubscriptions(
+        persistentSubscriptions as ESPersistentSubscription[],
+      );
+    });
   }
 
   async subscribeToPersistentSubscriptions(
@@ -167,9 +168,7 @@ export class EventStoreBus {
     subscriptionName: string,
   ): Promise<ExtendedPersistentSubscription> {
     try {
-      this.logger.log(`
-      Connecting to persistent subscription ${subscriptionName} on stream ${stream}!
-      `);
+      this.logger.log(`Connecting to persistent subscription ${subscriptionName} on stream ${stream}!`);
       const resolved = (await this.eventStore.connection.connectToPersistentSubscription(
         stream,
         subscriptionName,
@@ -182,7 +181,7 @@ export class EventStoreBus {
 
       return resolved;
     } catch (err) {
-      this.logger.error(err.message, err.stack);
+      this.logger.error(`[${stream}][${subscriptionName}] ${err.message}`, err.stack);
     }
   }
 

--- a/src/event-store/eventstore-cqrs/event-store.bus.ts
+++ b/src/event-store/eventstore-cqrs/event-store.bus.ts
@@ -54,14 +54,13 @@ export class EventStoreBus {
       return sub.type === EventStoreSubscriptionType.Persistent;
     });
 
-    this.eventStore.connection.on('connected', () => {
-      this.subscribeToCatchUpSubscriptions(
-        catchupSubscriptions as ESCatchUpSubscription[],
-      );
-      this.subscribeToPersistentSubscriptions(
-        persistentSubscriptions as ESPersistentSubscription[],
-      );
-    });
+    this.subscribeToCatchUpSubscriptions(
+      catchupSubscriptions as ESCatchUpSubscription[],
+    );
+
+    this.subscribeToPersistentSubscriptions(
+      persistentSubscriptions as ESPersistentSubscription[],
+    );
   }
 
   async subscribeToPersistentSubscriptions(
@@ -122,7 +121,7 @@ export class EventStoreBus {
     );
 
     try {
-      await this.eventStore.connection.appendToStream(stream, -2, [payload]);
+      await this.eventStore.getConnection().appendToStream(stream, -2, [payload]);
     } catch (err) {
       this.logger.error(err.message, err.stack);
     }
@@ -130,7 +129,7 @@ export class EventStoreBus {
 
   async publishAll(events: IEvent[], stream?: string) {
     try {
-      await this.eventStore.connection.appendToStream(stream, -2, (events || []).map(
+      await this.eventStore.getConnection().appendToStream(stream, -2, (events || []).map(
         (event: IEvent) => createEventData(
           v4(),
           event.constructor.name,
@@ -146,7 +145,7 @@ export class EventStoreBus {
   subscribeToCatchupSubscription(stream: string): ExtendedCatchUpSubscription {
     this.logger.log(`Catching up and subscribing to stream ${stream}!`);
     try {
-      return this.eventStore.connection.subscribeToStreamFrom(
+      return this.eventStore.getConnection().subscribeToStreamFrom(
         stream,
         0,
         true,
@@ -168,20 +167,19 @@ export class EventStoreBus {
     subscriptionName: string,
   ): Promise<ExtendedPersistentSubscription> {
     try {
-      this.logger.log(`Connecting to persistent subscription ${subscriptionName} on stream ${stream}!`);
-      const resolved = (await this.eventStore.connection.connectToPersistentSubscription(
+      const resolved = (await this.eventStore.getConnection().connectToPersistentSubscription(
         stream,
         subscriptionName,
         (sub, payload) => this.onEvent(sub, payload),
         (sub, reason, error) =>
           this.onDropped(sub as ExtendedPersistentSubscription, reason, error),
       )) as ExtendedPersistentSubscription;
-
+      this.logger.log(`Connection to persistent subscription ${subscriptionName} on stream ${stream} established!`);
       resolved.isLive = true;
-
       return resolved;
     } catch (err) {
       this.logger.error(`[${stream}][${subscriptionName}] ${err.message}`, err.stack);
+      this.reSubscribeToPersistentSubscription(stream, subscriptionName)
     }
   }
 
@@ -212,6 +210,16 @@ export class EventStoreBus {
   ) {
     subscription.isLive = false;
     this.logger.error(error.message, error.stack);
+    if((subscription as any)._subscriptionId!=undefined)
+      this.reSubscribeToPersistentSubscription((subscription as any)._streamId,(subscription as any)._subscriptionId)
+  }
+
+  reSubscribeToPersistentSubscription(
+    stream: string,
+    subscriptionName: string,
+  ){
+    this.logger.warn(`connecting to subscription ${subscriptionName} ${stream}. Retrying...`);
+    setTimeout((stream, subscriptionName) => this.subscribeToPersistentSubscription(stream, subscriptionName), 3000, stream, subscriptionName);
   }
 
   onLiveProcessingStarted(subscription: ExtendedCatchUpSubscription) {


### PR DESCRIPTION
persistent subscriptions lost connection either when:
* TcpConnection was closed with `Error: This socket has been ended by the other party.`
* Eventstore is down (back to life after some minutes)