### PR TITLE
feat: return WriteResult on eventstoreBus.publish

### DIFF
--- a/src/event-store/eventstore-cqrs/event-bus.provider.ts
+++ b/src/event-store/eventstore-cqrs/event-bus.provider.ts
@@ -81,11 +81,11 @@ export class EventBusProvider extends ObservableBus<IEvent>
   }
 
   publish<T extends IEvent>(event: T, stream: string) {
-    this._publisher.publish(event, stream);
+    return this._publisher.publish(event, stream);
   }
 
   publishAll(events: IEvent[]) {
-    (events || []).forEach(event => this._publisher.publish(event));
+    return Promise.all((events || []).map(event => this._publisher.publish(event)));
   }
 
   bind(handler: IEventHandler<IEvent>, name: string) {

--- a/src/event-store/eventstore-cqrs/event-publisher.ts
+++ b/src/event-store/eventstore-cqrs/event-publisher.ts
@@ -15,7 +15,7 @@ export class EventPublisher {
     const eventBus = this.eventBus;
     return class extends metatype {
       publish(event: IEvent) {
-        eventBus.publish(event, (event as IAggregateEvent).streamName);
+        return eventBus.publish(event, (event as IAggregateEvent).streamName);
       }
     };
   }
@@ -23,7 +23,7 @@ export class EventPublisher {
   mergeObjectContext<T extends AggregateRoot>(object: T): T {
     const eventBus = this.eventBus;
     object.publish = (event: IEvent) => {
-      eventBus.publish(event, (event as IAggregateEvent).streamName);
+      return eventBus.publish(event, (event as IAggregateEvent).streamName);
     };
     return object;
   }


### PR DESCRIPTION
It should be possible for clients to `await` for the successful write of events (using the `eventbus.publish`) or handle write errors. 

This propagates the response from the `nest-eventstore-client` to the client.